### PR TITLE
Fix: Add and Configure the missing @babel/plugin-transform-runtime plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,11 @@
+{
+  "presets": ["@babel/preset-env"],
+  "plugins": [
+    [
+      "@babel/plugin-transform-runtime",
+      {
+        "regenerator": true
+      }
+    ]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
     "build": "rollup -c",
     "start": "rollup -c -w",
     "format": "prettier src -w",
-    "prepare":"npm run build"
+    "prepare": "npm run build"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.6",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
-    "@babel/plugin-transform-runtime": "^7.9.6",
-    "@babel/preset-env": "^7.9.6",
+    "@babel/plugin-transform-runtime": "^7.28.0",
+    "@babel/preset-env": "^7.28.0",
     "@babel/preset-react": "^7.9.4",
     "@babel/runtime": "^7.9.6",
     "@rollup/plugin-babel": "^5.0.0",


### PR DESCRIPTION
# Description

# A similar fix was made in the first pull request https://github.com/openimis/openimis-fe-beneficiary_js/pull/2

> when trying to install dependencies to build the frontend, I noticed that one of the dependencies had a build failure as shown in the attached screenshot.

<img width="1037" height="374" alt="Capture d’écran 2025-08-08 005832" src="https://github.com/user-attachments/assets/f585a49a-0da9-42c6-a060-7ad0967ab15f" />

> I addressed this by adding the missing plugin and configuring it, now it installs and builds via Yarn with no issues and this repository is safe and functional.

> ## after integrating the missing plugin

<img width="545" height="119" alt="image" src="https://github.com/user-attachments/assets/41aa4ea9-d111-4e27-8373-a332f0a0a5de" />